### PR TITLE
Shellchecked script and added quick automation line

### DIFF
--- a/Clone_ZS_Repositories/make_ZSrepo.sh
+++ b/Clone_ZS_Repositories/make_ZSrepo.sh
@@ -39,7 +39,7 @@ Select the repository to copy:
    203) ZS 6.3 - 32 bit                  318) ZS 8.0 - 64 bit (openSSL 0.9.8)
    204) ZS 6.3 - 64 bit                  319) ZS 8.0 - 64 bit (openSSL 1.0)
    205) ZS 7.0 - 32 bit                  320) ZS 8.0 - 64 bit (Apache 2.4)
-   206) ZS 7.0 - 64 bit                  321) ZS 8.0 - power8  
+   206) ZS 7.0 - 64 bit                  321) ZS 8.0 - power8
    207) ZS 8.0 - 32 bit               .. 322) ZS 8.5 - 32 bit (openSSL 1.0)
    208) ZS 8.0 - 64 bit                  323) ZS 8.5 - 32 bit (Apache 2.4)
    209) ZS 8.5 - 32 bit                  324) ZS 8.5 - 64 bit (openSSL 1.0)
@@ -53,8 +53,8 @@ EOS
 
 echo -e "Input your selection [c] : \c"
 
-read choice
-case $(echo $choice) in
+read -r choice
+case $choice in
 	# RHEL
 	("103") export ZS="6.3"; export FL=rpm; export Rs="i386|noarch"; export OS="RHEL"; export ARCH="32bit";;
 	("104") export ZS="6.3"; export FL=rpm; export Rs="x86_64|noarch"; export OS="RHEL"; export ARCH="64bit";;
@@ -130,14 +130,16 @@ esac
 wget -nv http://repos.zend.com/zend.key -O zend.key
 
 mkdir -p $OS-ZS$ZS
-cd $OS-ZS$ZS
+cd $OS-ZS$ZS || exit
 wget -nv -O - http://repos.zend.com/zend-server/$ZS/files.lst | grep -E "^$FL/($Rs)" > ZS$ZS-$OS-$ARCH-repo-files.list
 sed -i "s@^$FL/@@g" ZS$ZS-$OS-$ARCH-repo-files.list
 
-for file in $(cat ZS$ZS-$OS-$ARCH-repo-files.list); do
-	mkdir -p $(dirname $file)
-	wget  -P $(dirname $file) -nv "http://repos.zend.com/zend-server/$ZS/$FL/$file"
-done
+while read -r file
+do
+        dirname=$(dirname "$file")
+	mkdir -p "$dirname"
+	wget  -P "$dirname" -nv "http://repos.zend.com/zend-server/$ZS/$FL/$file"
+done < ZS$ZS-$OS-$ARCH-repo-files.list
 
 cd ..
 
@@ -157,7 +159,7 @@ echo -e "\e[0mPlease enter the URL of this directory - it will be used to output
 echo -e "For example: \e[33mhttp://\e[1m192.168.0.17/ZS_local_repo\e[39m"
 echo
 echo -e "\e[4mhttp://\c"
-read URL
+read -r URL
 echo
 echo
 
@@ -165,7 +167,7 @@ echo
 repoFile="/etc/apt/sources.list.d/zend_local.list"
 repoText="deb http://$URL/$OS-ZS$ZS server non-free"
 
-if [ "$FL" = "rpm" -o "$FL" = "rpm_apache2.4" ]; then
+if [ "$FL" = "rpm" ] || [ "$FL" = "rpm_apache2.4" ]; then
 	archReal=$(cut -d"|" -f1 <<< "$Rs")
 	archNo=$(cut -d"|" -f2 <<< "$Rs")
 	repoFile="/etc/yum.repos.d/zend_local.repo"
@@ -217,14 +219,14 @@ fi
 echo -e "\e[0mSave the text between the lines as \e[1m$repoFile\e[0m :"
 
 echo -e "\e[2m-------------------------------------------------------------\e[1m\e[32m"
-echo -e $repoText
+echo -e "$repoText"
 echo -e "\e[0m\e[2m-------------------------------------------------------------\e[0m"
 
 
 
 exit 0
 
-
+cat << EOS
 ================================================
 Old repos:
 ================================================
@@ -232,8 +234,8 @@ Old repos:
    101) ZS 5.6 - 32 bit                  301) ZS 5.6 - 32 bit (openSSL 0.9.8)
    102) ZS 5.6 - 64 bit                  302) ZS 5.6 - 64 bit (openSSL 0.9.8)
 
-   201) ZS 5.6 - 32 bit               
-   202) ZS 5.6 - 64 bit               
+   201) ZS 5.6 - 32 bit
+   202) ZS 5.6 - 64 bit
 
 	("101") export ZS="5.6"; export FL=rpm; export Rs="i386|noarch"; export OS="RHEL"; export ARCH="32bit";;
 	("102") export ZS="5.6"; export FL=rpm; export Rs="x86_64|noarch"; export OS="RHEL"; export ARCH="64bit";;
@@ -245,3 +247,4 @@ Old repos:
 	("302") export ZS="5.6"; export FL=deb; export Rs=".*_all.deb$|.*_amd64.deb$|dists/.*"; export OS="Debian"; export ARCH="64bit";;
 
 ================================================
+EOS

--- a/Clone_ZS_Repositories/make_ZSrepo.sh
+++ b/Clone_ZS_Repositories/make_ZSrepo.sh
@@ -8,12 +8,10 @@
 ### 4. Verbose output / logging
 ### 5. Cloning of multiple repositories in one pass
 
-
+if [ $# -eq 0 ]
+then
 
 cat <<EOS
-
-
-
 This script will copy the selected repository to current directory:
 $PWD
 
@@ -52,6 +50,10 @@ Select the repository to copy:
 EOS
 
 echo -e "Input your selection [c] : \c"
+
+else
+choice=$1
+fi
 
 read -r choice
 case $choice in
@@ -143,6 +145,9 @@ done < ZS$ZS-$OS-$ARCH-repo-files.list
 
 cd ..
 
+if [ $# -eq 0 ]
+then
+
 echo -e "\e[1m\e[31m"
 cat <<EOT
 
@@ -222,7 +227,7 @@ echo -e "\e[2m-------------------------------------------------------------\e[1m
 echo -e "$repoText"
 echo -e "\e[0m\e[2m-------------------------------------------------------------\e[0m"
 
-
+fi
 
 exit 0
 

--- a/Clone_ZS_Repositories/make_ZSrepo.sh
+++ b/Clone_ZS_Repositories/make_ZSrepo.sh
@@ -50,12 +50,11 @@ Select the repository to copy:
 EOS
 
 echo -e "Input your selection [c] : \c"
-
+read -r choice
 else
 choice=$1
 fi
 
-read -r choice
 case $choice in
 	# RHEL
 	("103") export ZS="6.3"; export FL=rpm; export Rs="i386|noarch"; export OS="RHEL"; export ARCH="32bit";;


### PR DESCRIPTION
I fixed any shellcheck (http://www.shellcheck.net) issues  in the script and added a quick check if there are any any arguments. If there are, skip prompts.
The script can now be run like this:
./make_ZSrepo.sh [number]
And automated like this:
# All RHEL/CentOS/OEL versions...

for i in {103..115}; do ./make_ZSrepo.sh $1; done
